### PR TITLE
Add a hosted AgentKit talk

### DIFF
--- a/docs/research/agentkit-talk.md
+++ b/docs/research/agentkit-talk.md
@@ -1,0 +1,156 @@
+# AgentKit end-to-end (talk research)
+
+Primary sources only. Researched 2026-08-21.
+
+**Question:** How does AgentKit work end-to-end: connector → connection → connected account → tool call with injected user identity? What is the real GitHub / PR-summarization code?
+
+**Not in catalog:** `https://docs.scalekit.com/agentkit/tool-discovery/` returns 404. Tool listing lives on [optimized tools](https://docs.scalekit.com/agentkit/tools/scalekit-optimized-tools/) and the SDK tool pages.
+
+---
+
+## 1. Object definitions
+
+| Object | Official definition | Source |
+| --- | --- | --- |
+| **Connector** | Pre-built integration (GitHub, Gmail, Slack, Salesforce, Snowflake…). Each connector exposes a library of tools. | [overview](https://docs.scalekit.com/agentkit/overview/) |
+| **Connection** | Config you create once. Holds credentials Scalekit needs to talk to the connector (OAuth app credentials, scopes, redirect URI, or a name for API-key connectors). One connection serves all users. | [overview](https://docs.scalekit.com/agentkit/overview/), [connections](https://docs.scalekit.com/agentkit/connections/) |
+| **Connected account** | Per-user instance of a connection. Stores that user’s tokens and auth state. Created when the user authorizes. The agent uses this to act on that user. | [overview](https://docs.scalekit.com/agentkit/overview/), [connected accounts](https://docs.scalekit.com/agentkit/connected-accounts/) |
+| **Tool** | Connector-specific action (`github_repo_star`, `github_user_repos_list`, `slack_send_message`). Scalekit supplies the schema and runs the authenticated API call. The agent passes inputs. Scalekit injects the user’s credentials and returns structured output. | [overview](https://docs.scalekit.com/agentkit/overview/), [tools overview](https://docs.scalekit.com/agentkit/tools/overview/) |
+
+Connected-account states: `ACTIVE`, `EXPIRED`, `PENDING_AUTH`, `PENDING_VERIFICATION`, `DISCONNECTED`. Tool calls need `ACTIVE`. Source: [connected accounts](https://docs.scalekit.com/agentkit/connected-accounts/).
+
+A tool schema has `name`, `display_name`, `description`, `provider`, `category`, `input_schema`, `output_schema`. Official sample is `github_issue_create`. Source: [tools overview](https://docs.scalekit.com/agentkit/tools/overview/).
+
+---
+
+## 2. Real setup sequence (dashboard vs code)
+
+### Dashboard (once per environment)
+
+1. Create a Scalekit account at [app.scalekit.com](https://app.scalekit.com).
+2. Open **AgentKit → Connections**. New environments ship a default GitHub connection named `github-connect`, with Scalekit-managed credentials and scopes `user:email`, `repo`, `public_repo`. Copy the exact connection name. Source: [quickstart](https://docs.scalekit.com/agentkit/quickstart/).
+3. To use your own GitHub OAuth app: **Create Connection → GitHub → Use your own credentials**. Copy the Scalekit redirect URI (`https://<SCALEKIT_ENVIRONMENT_URL>/sso/v1/oauth/<CONNECTION_ID>/callback`). Paste it into the GitHub OAuth app. Enter Client ID and Client Secret. Save. Source: [GitHub connector](https://docs.scalekit.com/agentkit/connectors/github/), [connections](https://docs.scalekit.com/agentkit/connections/).
+4. Copy API credentials from **Developers → Settings → API Credentials**: `SCALEKIT_CLIENT_ID`, `SCALEKIT_CLIENT_SECRET`, env URL. Source: [quickstart](https://docs.scalekit.com/agentkit/quickstart/).
+5. Production: set **AgentKit → User Verification** to **Custom user verification**. Dev/internal: **Scalekit users only**. Source: [user verification](https://docs.scalekit.com/agentkit/user-verification/).
+
+Most teams create connections in the dashboard. Python can also create them in code with `scalekit_client.connection.create_environment_connection(..., flags=Flags(is_app=True))`. Source: [Python connections](https://docs.scalekit.com/agentkit/sdks/python/connections.md).
+
+### Code (per user)
+
+1. Install SDK. Init `ScalekitClient`.
+2. `get_or_create_connected_account` / `getOrCreateConnectedAccount` with `connection_name` + `identifier` (your app user ID).
+3. If status ≠ `ACTIVE`, call `get_authorization_link` / `getAuthorizationLink`. Send the hosted-page URL to the user. Scalekit handles the OAuth callback. Source: [authorize](https://docs.scalekit.com/agentkit/tools/authorize/).
+4. Production: after OAuth, Scalekit redirects to your `user_verify_url`. Call `verify_connected_account_user` / `verifyConnectedAccountUser` with `auth_request_id` + the same `identifier`. Source: [user verification](https://docs.scalekit.com/agentkit/user-verification/).
+5. Discover tools with `list_scoped_tools` / `listScopedTools(identifier, filter.connection_names)`. This is the list you pass to the LLM. Source: [optimized tools](https://docs.scalekit.com/agentkit/tools/scalekit-optimized-tools/).
+6. Execute with `execute_tool` / `executeTool`. Pass `identifier` + `connection_name` (or `connected_account_id`). Scalekit injects credentials.
+
+---
+
+## 3. Real SDK method names
+
+Packages: `@scalekit-sdk/node` ([Node SDK](https://docs.scalekit.com/agentkit/sdks/node/)), `scalekit-sdk-python` ([Python SDK](https://docs.scalekit.com/agentkit/sdks/python/)).
+
+| Action | Node (`scalekit.actions` / `scalekit.tools`) | Python (`scalekit_client.actions` / `.tools` / `.connection`) |
+| --- | --- | --- |
+| Init | `new ScalekitClient(envUrl, clientId, clientSecret)` | `ScalekitClient(env_url=, client_id=, client_secret=)` |
+| Upsert connected account | `actions.getOrCreateConnectedAccount` (alias `upsertConnectedAccount`) | `actions.get_or_create_connected_account` (alias `upsert_connected_account`) |
+| Auth link | `actions.getAuthorizationLink` | `actions.get_authorization_link` |
+| Verify identity | `actions.verifyConnectedAccountUser` | `actions.verify_connected_account_user` |
+| Get account (includes credentials) | `actions.getConnectedAccount` | `actions.get_connected_account` |
+| Execute tool (high-level) | `actions.executeTool({ toolName, toolInput, identifier, connectedAccountId, connector })` | `actions.execute_tool(tool_name=, tool_input=, identifier=, connection_name=, connected_account_id=)` |
+| List tools for one user | `tools.listScopedTools(identifier, { filter })` | `tools.list_scoped_tools(identifier, filter=)` |
+| Proxy HTTP | `actions.request({ connectionName, identifier, path, method })` | `actions.request(connection_name=, identifier=, path=, method=)` |
+
+Sources: [Node actions](https://docs.scalekit.com/agentkit/sdks/node/actions/), [Node tools](https://docs.scalekit.com/agentkit/sdks/node/tools/), [Python actions](https://docs.scalekit.com/agentkit/sdks/python/actions/), [Python tools](https://docs.scalekit.com/agentkit/sdks/python/tools.md).
+
+**Env-var clash (do not invent a third name):**
+
+- Quickstart uses `SCALEKIT_ENV_URL`.
+- SDK init pages and some example repos use `SCALEKIT_ENVIRONMENT_URL`.
+
+Connection names are workspace-specific. Do not hard-code them in production. Use `GITHUB_CONNECTION_NAME`. Source: [optimized tools](https://docs.scalekit.com/agentkit/tools/scalekit-optimized-tools/).
+
+---
+
+## 4. How identity is injected
+
+The identity you pass is `identifier` (your app’s user ID), not the GitHub username. Scalekit maps `identifier` + connection → connected account → stored tokens.
+
+### Path A — execute tool (recommended)
+
+`execute_tool` / `executeTool` selects the connected account with:
+
+- `identifier` + `connection_name` (dashboard connection name), or
+- `connected_account_id` (`ca_…`)
+
+Then: “Your agent passes inputs; Scalekit injects the user’s credentials and returns structured output.” Sources: [overview](https://docs.scalekit.com/agentkit/overview/), [optimized tools](https://docs.scalekit.com/agentkit/tools/scalekit-optimized-tools/).
+
+The GitHub connector first-call also accepts `connector: 'github'` + `identifier` (no connection name). Source: [GitHub connector](https://docs.scalekit.com/agentkit/connectors/github/).
+
+Response is a wrapper. Read `result.data` (Node) / `response.data` (Python).
+
+### Path B — proxy HTTP
+
+`actions.request` forwards `path` to the provider. Scalekit adds auth headers. Source: [custom tools](https://docs.scalekit.com/agentkit/tools/custom-tools.md).
+
+### Path C — raw token
+
+`get_connected_account` can return stored tokens. Official custom-tools guidance: do not take this path for agent tool calls. Use Path A or B.
+
+### Production identity check
+
+Custom verification: Scalekit stores tokens in pending verification, redirects to your `user_verify_url` with `auth_request_id` + `state`, your app reads the user from **session**, then `verify_connected_account_user(auth_request_id, identifier)`. Source: [user verification](https://docs.scalekit.com/agentkit/user-verification/).
+
+---
+
+## 5. Architecture in the docs
+
+```
+You (developer)  --configure once-->  Connection (credentials + config)
+Your users       --authenticate---->  Connected accounts (per-user auth state)
+Your agent       --call tools------>  Tools (pre-built + proxied)
+Scalekit tools   --authenticated API call-->  Third-party app (GitHub, Gmail, Slack…)
+```
+
+Source: [overview](https://docs.scalekit.com/agentkit/overview.md).
+
+---
+
+## 6. GitHub tools — no PR-summarize in the catalog
+
+GitHub connector: **217 tools**, OAuth 2.0. Source: [GitHub connector](https://docs.scalekit.com/agentkit/connectors/github/).
+
+**There is no `github_pull_request_summarize` tool.**
+
+Closest real tools for a “summarize this PR” demo:
+
+| Tool | What it does | Required inputs |
+| --- | --- | --- |
+| `github_pull_requests_list` | List PRs in a repo | `owner`, `repo` |
+| `github_pull_request_get` | Get one PR | `owner`, `repo`, `pull_number` |
+| `github_pull_request_files_list` | Files changed | `owner`, `repo`, `pull_number` |
+| `github_pull_request_commits_list` | Commits on a PR | `owner`, `repo`, `pull_number` |
+
+The model writes the summary from those payloads. That is application logic, not a Scalekit tool.
+
+Official GitHub sample is “star a repo” (`github_repo_star`), not PR summary. Source: [quickstart](https://docs.scalekit.com/agentkit/quickstart/).
+
+---
+
+## 7. Example repos
+
+| Repo | What it actually runs |
+| --- | --- |
+| [scalekit-developers/agent-auth-examples](https://github.com/scalekit-developers/agent-auth-examples) | Gmail fetch; optional GitHub if `GITHUB_CONNECTION_NAME` is set |
+| [scalekit-inc/python-connect-demos](https://github.com/scalekit-inc/python-connect-demos) | Gmail / Slack / Salesforce — no `github.py` |
+| [scalekit-inc/sample-langchain-agent](https://github.com/scalekit-inc/sample-langchain-agent) | Gmail + LangChain |
+| [scalekit-inc/google-adk-agent-example](https://github.com/scalekit-inc/google-adk-agent-example) | Gmail |
+| [scalekit-inc/meeting-prep-agent-example](https://github.com/scalekit-inc/meeting-prep-agent-example) | Calendar / Gmail / HubSpot / Slack |
+
+No official repo implements GitHub PR summarization.
+
+---
+
+## Talk one-liner
+
+A **connector** is the GitHub integration. A **connection** is your one-time OAuth app config. A **connected account** is one user after consent. A **tool call** sends `identifier`; Scalekit injects that user’s token. There is no PR-summarize tool — call `github_pull_request_get` (and files/commits) and let the model write the summary.

--- a/public/talks/agentkit/index.html
+++ b/public/talks/agentkit/index.html
@@ -1,0 +1,974 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How AgentKit works — Saif Ali Shaik</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        /* === THEME: Scalekit.com === */
+        :root {
+            --ink: #0e1828;
+            --ink-2: #4b5563;
+            --paper: #ffffff;
+            --green: #16a34a;
+            --green-deep: #0e8a4a;
+            --forest: #1c3b32;
+            --plus: rgba(22, 163, 74, 0.14);
+            --line: #d7e3dc;
+            --stage-bg: #0e1828;
+            --slide-bg: #ffffff;
+            --font-display: "Geist", ui-sans-serif, sans-serif;
+            --font-serif: "DM Serif Display", ui-serif, Georgia, serif;
+            --font-body: "Inter", ui-sans-serif, sans-serif;
+            --font-mono: "JetBrains Mono", ui-monospace, monospace;
+            --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        /* === viewport-base.css (required, in full) === */
+        html,
+        body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            overflow: hidden;
+            background: var(--stage-bg, #000);
+        }
+
+        .deck-viewport {
+            position: fixed;
+            inset: 0;
+            overflow: hidden;
+            background: var(--stage-bg, #000);
+        }
+
+        .deck-stage {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 1920px;
+            height: 1080px;
+            overflow: hidden;
+            transform-origin: 0 0;
+            background: var(--slide-bg, #fff);
+        }
+
+        .slide {
+            position: absolute;
+            inset: 0;
+            width: 1920px;
+            height: 1080px;
+            overflow: hidden;
+            display: block;
+            visibility: hidden;
+            opacity: 0;
+            pointer-events: none;
+            background: var(--slide-bg, #fff);
+        }
+
+        .slide.active,
+        .slide.visible {
+            visibility: visible;
+            opacity: 1;
+            pointer-events: auto;
+            z-index: 1;
+        }
+
+        img, video, canvas, svg {
+            max-width: 100%;
+            max-height: 100%;
+        }
+
+        .deck-controls {
+            position: fixed;
+            left: 50%;
+            bottom: 22px;
+            transform: translateX(-50%);
+            z-index: 1000;
+        }
+
+        @media print {
+            html, body { width: 1920px; height: auto; overflow: visible; background: #fff; }
+            .deck-viewport { position: static; overflow: visible; background: #fff; }
+            .deck-stage { position: static; width: auto; height: auto; transform: none !important; background: none; }
+            .slide {
+                position: relative;
+                display: block !important;
+                visibility: visible !important;
+                opacity: 1 !important;
+                pointer-events: auto !important;
+                width: 1920px;
+                height: 1080px;
+                break-after: page;
+                page-break-after: always;
+            }
+            .slide:last-child { break-after: auto; page-break-after: auto; }
+            .deck-controls { display: none !important; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                transition-duration: 0.2s !important;
+            }
+        }
+
+        /* === SLIDE CHROME === */
+        .slide {
+            color: var(--ink);
+            font-family: var(--font-body);
+            background-color: #ffffff;
+        }
+
+        .plus {
+            background-image:
+                radial-gradient(1200px 700px at 80% 0%, rgba(22, 163, 74, 0.08), transparent 60%),
+                linear-gradient(180deg, #ffffff 0%, #f3faf5 100%);
+        }
+
+        .plus::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background-image:
+                linear-gradient(var(--plus) 2px, transparent 2px),
+                linear-gradient(90deg, var(--plus) 2px, transparent 2px);
+            background-size: 56px 56px;
+            mask-image: radial-gradient(ellipse at 80% 15%, black 18%, transparent 68%);
+            pointer-events: none;
+        }
+
+        .forest { background: var(--forest); color: #f5f5f7; }
+
+        .pad {
+            position: absolute;
+            left: 120px;
+            right: 120px;
+            top: 88px;
+            bottom: 88px;
+            z-index: 2;
+        }
+
+        .kicker {
+            font-family: var(--font-mono);
+            font-size: 18px;
+            font-weight: 500;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--green-deep);
+        }
+
+        .forest .kicker { color: #86efac; }
+
+        h1, h2 {
+            font-family: var(--font-display);
+            font-weight: 400;
+            font-style: normal;
+            letter-spacing: -0.03em;
+            line-height: 1.08;
+        }
+
+        .display { font-size: 80px; max-width: 18ch; }
+        .display-lg { font-size: 96px; max-width: 16ch; }
+        .punch {
+            font-family: var(--font-serif);
+            font-style: italic;
+            font-weight: 400;
+            color: var(--green);
+        }
+
+        .sub {
+            margin-top: 32px;
+            font-size: 30px;
+            line-height: 1.45;
+            color: var(--ink-2);
+            max-width: 32ch;
+        }
+
+        .forest .sub { color: #d1d5db; }
+
+        .center {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            height: 100%;
+        }
+
+        .center.mid { align-items: center; text-align: center; }
+        .center.mid .sub { margin-left: auto; margin-right: auto; }
+
+        .page {
+            position: absolute;
+            right: 64px;
+            bottom: 40px;
+            font-family: var(--font-mono);
+            font-size: 16px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--ink-2);
+            z-index: 3;
+        }
+
+        .forest .page { color: #9ca3af; }
+
+        .steps {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 32px;
+            margin-top: 56px;
+        }
+
+        .step {
+            border-top: 2px solid var(--line);
+            padding-top: 24px;
+        }
+
+        .step small {
+            font-family: var(--font-mono);
+            font-size: 16px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--green-deep);
+        }
+
+        .step strong {
+            display: block;
+            margin-top: 14px;
+            font-family: var(--font-display);
+            font-weight: 500;
+            font-size: 36px;
+            letter-spacing: -0.03em;
+        }
+
+        .step p {
+            margin-top: 14px;
+            font-size: 22px;
+            line-height: 1.4;
+            color: var(--ink-2);
+            max-width: 24ch;
+        }
+
+        .pill {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-size: 16px;
+            font-weight: 500;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            border: 1px solid var(--line);
+            border-radius: 10px;
+            padding: 10px 16px;
+            background: #fff;
+        }
+
+        /* === FLOW DIAGRAM === */
+        .flow {
+            margin-top: 48px;
+            display: flex;
+            flex-direction: column;
+            gap: 28px;
+        }
+
+        .row {
+            display: grid;
+            grid-template-columns: 1fr 88px 1fr 88px 1fr;
+            align-items: stretch;
+            gap: 16px;
+        }
+
+        .box {
+            border: 2px solid var(--line);
+            background: #fff;
+            border-radius: 14px;
+            padding: 22px 26px;
+            min-height: 120px;
+        }
+
+        .box.who {
+            background: #f3faf5;
+            border-color: #b7e4c7;
+        }
+
+        .box.sk {
+            background: var(--forest);
+            border-color: var(--forest);
+            color: #f5f5f7;
+        }
+
+        .box .who-label,
+        .box .sk .who-label {
+            font-family: var(--font-mono);
+            font-size: 14px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--green-deep);
+            margin-bottom: 8px;
+        }
+
+        .box.sk .who-label { color: #86efac; }
+
+        .box strong {
+            display: block;
+            font-family: var(--font-display);
+            font-size: 28px;
+            font-weight: 500;
+            letter-spacing: -0.02em;
+        }
+
+        .box p {
+            margin-top: 6px;
+            font-size: 18px;
+            color: var(--ink-2);
+            line-height: 1.35;
+        }
+
+        .box.sk p { color: #d1d5db; }
+
+        .arrow {
+            font-family: var(--font-mono);
+            font-size: 14px;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--green-deep);
+            text-align: center;
+            line-height: 1.3;
+        }
+
+        /* === CODE === */
+        .code-wrap {
+            margin-top: 28px;
+            background: #12261f;
+            color: #e8f5ec;
+            border-radius: 16px;
+            padding: 36px 40px;
+            font-family: var(--font-mono);
+            font-size: 26px;
+            line-height: 1.55;
+            overflow: hidden;
+        }
+
+        .code-wrap .cm { color: #86efac; }
+        .code-wrap .ky { color: #86efac; }
+        .code-wrap .st { color: #bbf7d0; }
+        .code-wrap .fn { color: #f5f5f7; }
+        .code-wrap mark {
+            background: rgba(22, 163, 74, 0.28);
+            color: inherit;
+            border-radius: 4px;
+            padding: 0 4px;
+        }
+
+        .caption {
+            margin-top: 20px;
+            font-size: 22px;
+            color: var(--ink-2);
+        }
+
+        /* Diagram Design figures sit on the slide paper. No extra chrome. */
+        svg.fig {
+            display: block;
+            width: 1680px;
+            height: 680px;
+            margin-top: 16px;
+        }
+
+        .reveal {
+            opacity: 0;
+            transition: opacity 180ms var(--ease-out);
+        }
+
+        .slide.visible .reveal { opacity: 1; }
+        .slide.visible .reveal:nth-child(2) { transition-delay: 40ms; }
+        .slide.visible .reveal:nth-child(3) { transition-delay: 80ms; }
+
+        .edit-hotzone {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 80px;
+            height: 80px;
+            z-index: 10000;
+            cursor: pointer;
+        }
+
+        .edit-toggle {
+            position: fixed;
+            top: 16px;
+            left: 16px;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+            z-index: 10001;
+            border: 0;
+            background: var(--forest);
+            color: #fff;
+            font-family: var(--font-mono);
+            font-size: 12px;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            padding: 8px 12px;
+            border-radius: 8px;
+        }
+
+        .edit-toggle.show,
+        .edit-toggle.active {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        [contenteditable="true"] {
+            outline: 1px dashed var(--green);
+            outline-offset: 4px;
+        }
+
+        :root {
+            --motion-fast: 160ms;
+            --motion-step: 480ms;
+            --motion-hold: 720ms;
+            --motion-ease: cubic-bezier(.2, .8, .2, 1);
+        }
+
+        .motion-ready [data-motion-item] {
+            opacity: 0;
+            transform: translateY(8px);
+            transform-box: fill-box;
+            transform-origin: center;
+            transition: opacity var(--motion-step) var(--motion-ease),
+                        transform var(--motion-step) var(--motion-ease);
+            pointer-events: none;
+        }
+
+        .motion-ready [data-motion-item].is-visible {
+            opacity: 1;
+            transform: none;
+            pointer-events: auto;
+        }
+
+        .build-hint {
+            position: absolute;
+            left: 160px;
+            bottom: 36px;
+            z-index: 3;
+            font-family: var(--font-mono);
+            font-size: 16px;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--color-muted, #4b5563);
+        }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .motion-ready [data-motion-item] {
+                opacity: 1 !important;
+                transform: none !important;
+            }
+            .build-hint { display: none; }
+        }
+
+        @media print {
+            [data-motion-item] {
+                opacity: 1 !important;
+                transform: none !important;
+            }
+            .build-hint { display: none; }
+        }
+    </style>
+</head>
+<body>
+    <div class="edit-hotzone"></div>
+    <button class="edit-toggle" id="editToggle" title="Edit mode (E)">Edit</button>
+
+    <div class="deck-viewport">
+        <main class="deck-stage" id="deckStage">
+
+            <section class="slide plus">
+                <div class="pad center mid">
+                    <p class="pill reveal">How AgentKit works</p>
+                    <h1 class="display-lg reveal" style="margin-top:40px">Let the agent act as the user.<br>
+                        <span class="punch">Not a shared service account.</span>
+                    </h1>
+                    <p class="sub reveal">A walkthrough. Then a live demo.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad center">
+                    <p class="kicker reveal">The moment</p>
+                    <h2 class="display reveal">Everyone wants an agent in the app.</h2>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad center">
+                    <p class="kicker reveal">You have already seen this</p>
+                    <h2 class="display reveal">Linear. Von.<br>A chat. Then work happens.</h2>
+                    <p class="sub reveal">“Do this on my project.” The agent does it as that user.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad center">
+                    <p class="kicker reveal">The hard part</p>
+                    <h2 class="display reveal">The model is not the hard part.</h2>
+                    <p class="sub reveal">The agent has no login. It cannot call GitHub as you.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide forest">
+                <div class="pad center">
+                    <p class="kicker reveal">Wrong path</p>
+                    <h2 class="display reveal">A shared service account is the wrong identity.</h2>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide plus">
+                <div class="pad center mid">
+                    <p class="kicker reveal">The question</p>
+                    <h2 class="display-lg reveal">How does Scalekit power this?</h2>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad" data-motion-root data-motion-mode="step" data-step-count="6" data-step-current="0" data-frame="start">
+                    <p class="kicker">Architecture · Next builds it</p>
+                    <h2 style="font-size:44px;margin-top:8px">You configure once. Users authorize. The agent calls tools.</h2>
+                    <svg class="fig" viewBox="0 0 1280 560" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="arch-title arch-desc">
+                        <title id="arch-title">AgentKit architecture</title>
+                        <desc id="arch-desc">A developer configures a GitHub connection. A user authorizes a connected account. An agent calls tools. Scalekit injects that user’s credentials and calls GitHub.</desc>
+                        <defs>
+                            <marker id="arch-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#4b5563"/></marker>
+                            <marker id="arch-arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#16a34a"/></marker>
+                            <marker id="arch-arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#2e5aa8"/></marker>
+                        </defs>
+
+                        <g data-motion-item data-step="1" aria-label="Step 1: Scalekit zone and the GitHub connection">
+                            <rect x="360" y="40" width="480" height="440" rx="8" fill="rgba(14,24,40,0.02)" stroke="rgba(14,24,40,0.10)" stroke-width="0.8"/>
+                            <rect x="536" y="44" width="128" height="16" rx="2" fill="#ffffff"/>
+                            <text x="600" y="56" fill="rgba(14,24,40,0.40)" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.14em">SCALEKIT</text>
+                            <rect x="400" y="80" width="240" height="80" rx="6" fill="#ffffff"/>
+                            <rect x="400" y="80" width="240" height="80" rx="6" fill="#ffffff" stroke="#0e1828" stroke-width="1"/>
+                            <rect x="408" y="88" width="88" height="16" rx="2" fill="transparent" stroke="rgba(14,24,40,0.40)" stroke-width="0.8"/>
+                            <text x="452" y="100" fill="rgba(14,24,40,0.80)" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CONNECTION</text>
+                            <text x="520" y="124" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">github-connect</text>
+                            <text x="520" y="144" fill="#4b5563" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle">OAuth + scopes</text>
+                        </g>
+
+                        <g data-motion-item data-step="2" aria-label="Step 2: User authorizes a connected account">
+                            <line x1="520" y1="160" x2="520" y2="200" stroke="#4b5563" stroke-width="1.2" marker-end="url(#arch-arrow)"/>
+                            <rect x="532" y="168" width="88" height="16" rx="2" fill="#ffffff"/>
+                            <text x="576" y="180" fill="#6b7280" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">SCOPES</text>
+                            <rect x="380" y="200" width="280" height="96" rx="6" fill="#ffffff"/>
+                            <rect x="380" y="200" width="280" height="96" rx="6" fill="rgba(22,163,74,0.10)" stroke="#16a34a" stroke-width="1"/>
+                            <rect x="388" y="208" width="56" height="16" rx="2" fill="transparent" stroke="rgba(22,163,74,0.50)" stroke-width="0.8"/>
+                            <text x="416" y="220" fill="#16a34a" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">ACCOUNT</text>
+                            <text x="520" y="248" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Connected account</text>
+                            <text x="520" y="272" fill="#4b5563" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle">identifier · ACTIVE</text>
+                        </g>
+
+                        <g data-motion-item data-step="3" aria-label="Step 3: Your agent">
+                            <rect x="48" y="360" width="200" height="80" rx="6" fill="#ffffff"/>
+                            <rect x="48" y="360" width="200" height="80" rx="6" fill="rgba(75,85,99,0.10)" stroke="#6b7280" stroke-width="1"/>
+                            <rect x="56" y="368" width="40" height="16" rx="2" fill="transparent" stroke="rgba(107,114,128,0.40)" stroke-width="0.8"/>
+                            <text x="76" y="380" fill="rgba(107,114,128,0.80)" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">APP</text>
+                            <text x="148" y="404" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Your agent</text>
+                            <text x="148" y="424" fill="#4b5563" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle">executeTool</text>
+                        </g>
+
+                        <g data-motion-item data-step="4" aria-label="Step 4: Agent calls the tool catalog">
+                            <line x1="248" y1="400" x2="400" y2="400" stroke="#4b5563" stroke-width="1.2" marker-end="url(#arch-arrow)"/>
+                            <rect x="284" y="372" width="80" height="16" rx="2" fill="#ffffff"/>
+                            <text x="324" y="384" fill="#6b7280" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">EXECUTE</text>
+                            <rect x="400" y="360" width="240" height="80" rx="6" fill="#ffffff"/>
+                            <rect x="400" y="360" width="240" height="80" rx="6" fill="#ffffff" stroke="#0e1828" stroke-width="1"/>
+                            <rect x="408" y="368" width="48" height="16" rx="2" fill="transparent" stroke="rgba(14,24,40,0.40)" stroke-width="0.8"/>
+                            <text x="432" y="380" fill="rgba(14,24,40,0.80)" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">TOOLS</text>
+                            <text x="520" y="404" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Tool catalog</text>
+                            <text x="520" y="424" fill="#4b5563" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle">github_pull_request_get</text>
+                        </g>
+
+                        <g data-motion-item data-step="5" aria-label="Step 5: Scalekit injects the user identifier">
+                            <line x1="520" y1="296" x2="520" y2="360" stroke="#16a34a" stroke-width="1.2" marker-end="url(#arch-arrow-accent)"/>
+                            <rect x="532" y="316" width="112" height="16" rx="2" fill="#ffffff"/>
+                            <text x="588" y="328" fill="#16a34a" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">IDENTIFIER</text>
+                        </g>
+
+                        <g data-motion-item data-step="6" aria-label="Step 6: GitHub is called as that user">
+                            <line x1="640" y1="400" x2="1000" y2="400" stroke="#2e5aa8" stroke-width="1.2" marker-end="url(#arch-arrow-link)"/>
+                            <rect x="780" y="372" width="80" height="16" rx="2" fill="#ffffff"/>
+                            <text x="820" y="384" fill="#2e5aa8" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">GET PR</text>
+                            <rect x="1000" y="360" width="200" height="80" rx="6" fill="#ffffff"/>
+                            <rect x="1000" y="360" width="200" height="80" rx="6" fill="rgba(14,24,40,0.03)" stroke="rgba(14,24,40,0.30)" stroke-width="1"/>
+                            <rect x="1008" y="368" width="72" height="16" rx="2" fill="transparent" stroke="rgba(14,24,40,0.30)" stroke-width="0.8"/>
+                            <text x="1044" y="380" fill="rgba(14,24,40,0.70)" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">EXTERNAL</text>
+                            <text x="1100" y="404" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">GitHub</text>
+                            <text x="1100" y="424" fill="#4b5563" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle">as that user</text>
+                        </g>
+                    </svg>
+                    <p class="build-hint">Next adds a piece · <span data-motion-step-label>0</span> / 6</p>
+                    <p class="sr-only" data-motion-status role="status" aria-live="polite" aria-atomic="true"></p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad" data-motion-root data-motion-mode="step" data-step-count="6" data-step-current="0" data-frame="start">
+                    <p class="kicker">Sequence · Next builds it</p>
+                    <h2 style="font-size:44px;margin-top:8px">Scalekit injects that identity. The token never sits in your agent.</h2>
+                    <svg class="fig" viewBox="0 0 1280 560" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="seq-title seq-desc">
+                        <title id="seq-title">Tool call sequence</title>
+                        <desc id="seq-desc">The agent calls executeTool. Scalekit injects the connected-account token, calls GitHub, and returns structured PR data to the agent.</desc>
+                        <defs>
+                            <marker id="seq-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#4b5563"/></marker>
+                            <marker id="seq-arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#16a34a"/></marker>
+                            <marker id="seq-arrow-link" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#2e5aa8"/></marker>
+                        </defs>
+
+                        <g data-motion-item data-step="1" aria-label="Step 1: Agent, Scalekit, and GitHub">
+                            <line x1="200" y1="112" x2="200" y2="480" stroke="rgba(14,24,40,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+                            <line x1="640" y1="112" x2="640" y2="480" stroke="rgba(14,24,40,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+                            <line x1="1080" y1="112" x2="1080" y2="480" stroke="rgba(14,24,40,0.20)" stroke-width="1" stroke-dasharray="3,3"/>
+                            <rect x="120" y="32" width="160" height="64" rx="6" fill="#ffffff" stroke="#0e1828" stroke-width="1"/>
+                            <text x="200" y="68" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Agent</text>
+                            <rect x="560" y="32" width="160" height="64" rx="6" fill="rgba(22,163,74,0.10)" stroke="#16a34a" stroke-width="1"/>
+                            <text x="640" y="68" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Scalekit</text>
+                            <rect x="1000" y="32" width="160" height="64" rx="6" fill="rgba(14,24,40,0.03)" stroke="rgba(14,24,40,0.30)" stroke-width="1"/>
+                            <text x="1080" y="68" fill="#0e1828" font-size="16" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">GitHub</text>
+                        </g>
+
+                        <g data-motion-item data-step="2" aria-label="Step 2: Agent calls executeTool">
+                            <rect x="196" y="160" width="8" height="24" fill="rgba(14,24,40,0.06)" stroke="#4b5563" stroke-width="0.8"/>
+                            <rect x="636" y="160" width="8" height="256" fill="rgba(14,24,40,0.06)" stroke="#4b5563" stroke-width="0.8"/>
+                            <line x1="208" y1="168" x2="632" y2="168" stroke="#4b5563" stroke-width="1.2" marker-end="url(#seq-arrow)"/>
+                            <rect x="336" y="140" width="168" height="16" rx="2" fill="#ffffff"/>
+                            <text x="420" y="152" fill="#6b7280" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">EXECUTE TOOL</text>
+                        </g>
+
+                        <g data-motion-item data-step="3" aria-label="Step 3: Scalekit injects the user token">
+                            <path d="M 648,232 H 760 Q 768,232 768,240 V 248 Q 768,256 760,256 H 648" fill="none" stroke="#16a34a" stroke-width="1.2" marker-end="url(#seq-arrow-accent)"/>
+                            <rect x="776" y="232" width="128" height="16" rx="2" fill="#ffffff"/>
+                            <text x="840" y="244" fill="#16a34a" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">INJECT TOKEN</text>
+                        </g>
+
+                        <g data-motion-item data-step="4" aria-label="Step 4: Scalekit calls GitHub as that user">
+                            <rect x="1076" y="280" width="8" height="80" fill="rgba(14,24,40,0.06)" stroke="#4b5563" stroke-width="0.8"/>
+                            <line x1="648" y1="296" x2="1072" y2="296" stroke="#2e5aa8" stroke-width="1.2" marker-end="url(#seq-arrow-link)"/>
+                            <rect x="792" y="268" width="136" height="16" rx="2" fill="#ffffff"/>
+                            <text x="860" y="280" fill="#2e5aa8" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">GET /PULLS/42</text>
+                        </g>
+
+                        <g data-motion-item data-step="5" aria-label="Step 5: GitHub returns the pull request">
+                            <line x1="1072" y1="344" x2="648" y2="344" stroke="#4b5563" stroke-width="1.2" stroke-dasharray="5,4" marker-end="url(#seq-arrow)"/>
+                            <rect x="808" y="316" width="88" height="16" rx="2" fill="#ffffff"/>
+                            <text x="852" y="328" fill="#6b7280" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">PR JSON</text>
+                        </g>
+
+                        <g data-motion-item data-step="6" aria-label="Step 6: Structured data returns to the agent">
+                            <rect x="196" y="400" width="8" height="24" fill="rgba(14,24,40,0.06)" stroke="#4b5563" stroke-width="0.8"/>
+                            <line x1="632" y1="408" x2="208" y2="408" stroke="#16a34a" stroke-width="1.2" stroke-dasharray="5,4" marker-end="url(#seq-arrow-accent)"/>
+                            <rect x="336" y="380" width="168" height="16" rx="2" fill="#ffffff"/>
+                            <text x="420" y="392" fill="#16a34a" font-size="12" font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.06em">RESULT.DATA</text>
+                        </g>
+                    </svg>
+                    <p class="build-hint">Next adds a piece · <span data-motion-step-label>0</span> / 6</p>
+                    <p class="sr-only" data-motion-status role="status" aria-live="polite" aria-atomic="true"></p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad">
+                    <p class="kicker reveal">In code · 1 of 3 · create the account</p>
+                    <h2 class="reveal" style="font-size:44px;margin-top:10px">connectionName must match the dashboard.</h2>
+                    <pre class="code-wrap reveal"><span class="cm">// docs.scalekit.com/agentkit/quickstart</span>
+<span class="ky">const</span> { connectedAccount } = <span class="ky">await</span> actions.<span class="fn">getOrCreateConnectedAccount</span>({
+  connectionName: <span class="st">'github-connect'</span>,
+  identifier: <mark><span class="st">'user_123'</span></mark>,
+});</pre>
+                    <p class="caption reveal">New Scalekit environments already have a GitHub connection named <code>github-connect</code>.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad">
+                    <p class="kicker reveal">In code · 2 of 3 · user says yes</p>
+                    <h2 class="reveal" style="font-size:44px;margin-top:10px">Do not call tools until status is ACTIVE.</h2>
+                    <pre class="code-wrap reveal"><span class="ky">if</span> (connectedAccount.status !== ConnectorStatus.ACTIVE) {
+  <span class="ky">const</span> { link } = <span class="ky">await</span> actions.<span class="fn">getAuthorizationLink</span>({
+    connectionName: <span class="st">'github-connect'</span>,
+    identifier: <span class="st">'user_123'</span>,
+  });
+  <span class="cm">// redirect the user to link, then resume</span>
+}</pre>
+                    <p class="caption reveal">Scalekit stores the tokens. You store only the user identifier.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad">
+                    <p class="kicker reveal">In code · 3 of 3 · fetch the PR</p>
+                    <h2 class="reveal" style="font-size:44px;margin-top:10px">There is no summarize tool. There is a get tool.</h2>
+                    <pre class="code-wrap reveal"><span class="ky">const</span> result = <span class="ky">await</span> actions.<span class="fn">executeTool</span>({
+  toolName: <span class="st">'github_pull_request_get'</span>,
+  identifier: <mark><span class="st">'user_123'</span></mark>,
+  connector: <span class="st">'github-connect'</span>,
+  toolInput: { owner: <span class="st">'acme'</span>, repo: <span class="st">'app'</span>, pull_number: <span class="st">42</span> },
+});
+<span class="cm">// result.data is the PR. Your model writes the summary.</span></pre>
+                    <p class="caption reveal">Real tool name from docs.scalekit.com/agentkit/connectors/github</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad center">
+                    <p class="kicker reveal">What the agent does next</p>
+                    <h2 class="display reveal">Scalekit returns the PR.<br>Your model writes the summary.</h2>
+                    <p class="sub reveal">Optional next call: <code>github_pull_request_files_list</code>.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide plus">
+                <div class="pad center mid">
+                    <p class="kicker reveal">Live</p>
+                    <h2 class="display-lg reveal">Today we ship it.</h2>
+                    <p class="sub reveal">A small app on Render. Sign in with GitHub. Fetch a PR. Summarize it.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide">
+                <div class="pad center">
+                    <p class="kicker reveal">Then the dashboard</p>
+                    <h2 class="display reveal">You will see the connected account.</h2>
+                    <p class="sub reveal">The approved identity. The tool calls. The proof.</p>
+                </div>
+                <p class="page"></p>
+            </section>
+
+            <section class="slide forest">
+                <div class="pad center mid">
+                    <p class="kicker reveal">The point</p>
+                    <h2 class="display-lg reveal">You can ship this today.<br>
+                        <span class="punch">The demo is the proof.</span>
+                    </h2>
+                </div>
+                <p class="page"></p>
+            </section>
+
+        </main>
+    </div>
+
+    <div class="deck-controls" aria-hidden="true"></div>
+
+    <script>
+        const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+        class DiagramBuild {
+            constructor(root) {
+                this.root = root;
+                this.count = Number(root.dataset.stepCount) || 0;
+                this.step = 0;
+                this.items = [...root.querySelectorAll('[data-motion-item]')];
+                this.label = root.querySelector('[data-motion-step-label]');
+                this.status = root.querySelector('[data-motion-status]');
+                this.root.classList.add('motion-ready');
+                this.render(0, false);
+            }
+
+            render(next, announce) {
+                this.step = Math.max(0, Math.min(this.count, next));
+                this.root.dataset.stepCurrent = String(this.step);
+                this.root.dataset.frame = this.step === this.count ? 'end' : this.step === 0 ? 'start' : 'step';
+                this.items.forEach((item) => {
+                    const itemStep = Number(item.dataset.step);
+                    item.classList.toggle('is-visible', itemStep <= this.step);
+                });
+                if (this.label) this.label.textContent = String(this.step);
+                if (announce && this.status) {
+                    this.status.textContent = 'Step ' + this.step + ' of ' + this.count;
+                }
+            }
+
+            next() {
+                if (reduceMotion.matches || this.step >= this.count) return false;
+                this.render(this.step + 1, true);
+                return true;
+            }
+
+            prev() {
+                if (reduceMotion.matches || this.step <= 0) return false;
+                this.render(this.step - 1, true);
+                return true;
+            }
+
+            reset() {
+                this.render(0, false);
+            }
+        }
+
+        class SlidePresentation {
+            constructor() {
+                this.slides = document.querySelectorAll('.slide');
+                this.currentSlide = 0;
+                this.stage = document.getElementById('deckStage');
+                this.builds = new Map();
+                document.querySelectorAll('[data-motion-root]').forEach((root) => {
+                    this.builds.set(root, new DiagramBuild(root));
+                });
+                this.numberPages();
+                this.setupStageScale();
+                this.setupKeyboardNav();
+                this.setupTouchNav();
+                this.setupWheelNav();
+                this.showSlide(0);
+            }
+
+            buildOn(slide) {
+                const root = slide.querySelector('[data-motion-root]');
+                return root ? this.builds.get(root) : null;
+            }
+
+            numberPages() {
+                const total = this.slides.length;
+                this.slides.forEach((slide, i) => {
+                    const el = slide.querySelector('.page');
+                    if (el) el.textContent = String(i + 1).padStart(2, '0') + ' / ' + String(total).padStart(2, '0');
+                });
+            }
+
+            setupStageScale() {
+                const scale = () => {
+                    const factor = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+                    const x = (window.innerWidth - 1920 * factor) / 2;
+                    const y = (window.innerHeight - 1080 * factor) / 2;
+                    this.stage.style.transform = `translate(${x}px, ${y}px) scale(${factor})`;
+                };
+                scale();
+                window.addEventListener('resize', scale);
+            }
+
+            setupKeyboardNav() {
+                document.addEventListener('keydown', (e) => {
+                    if (e.target.getAttribute('contenteditable')) return;
+                    if (['ArrowRight', 'ArrowDown', 'PageDown', ' ', 'Enter'].includes(e.key)) {
+                        e.preventDefault();
+                        this.forward();
+                    }
+                    if (['ArrowLeft', 'ArrowUp', 'PageUp', 'Backspace'].includes(e.key)) {
+                        e.preventDefault();
+                        this.back();
+                    }
+                    if (e.key === 'Home') this.showSlide(0);
+                    if (e.key === 'End') this.showSlide(this.slides.length - 1);
+                });
+            }
+
+            forward() {
+                const build = this.buildOn(this.slides[this.currentSlide]);
+                if (build && build.next()) return;
+                this.showSlide(this.currentSlide + 1);
+            }
+
+            back() {
+                const build = this.buildOn(this.slides[this.currentSlide]);
+                if (build && build.prev()) return;
+                this.showSlide(this.currentSlide - 1);
+            }
+
+            setupTouchNav() {
+                let startX = 0;
+                document.addEventListener('touchstart', (e) => {
+                    startX = e.changedTouches[0].screenX;
+                }, { passive: true });
+                document.addEventListener('touchend', (e) => {
+                    const dx = e.changedTouches[0].screenX - startX;
+                    if (dx < -40) this.forward();
+                    if (dx > 40) this.back();
+                }, { passive: true });
+            }
+
+            setupWheelNav() {
+                let locked = false;
+                window.addEventListener('wheel', (e) => {
+                    if (locked) return;
+                    if (Math.abs(e.deltaY) < 20) return;
+                    locked = true;
+                    if (e.deltaY > 0) this.forward();
+                    else this.back();
+                    setTimeout(() => { locked = false; }, 400);
+                }, { passive: true });
+            }
+
+            showSlide(index) {
+                this.currentSlide = Math.max(0, Math.min(index, this.slides.length - 1));
+                this.slides.forEach((slide, i) => {
+                    slide.classList.toggle('active', i === this.currentSlide);
+                    slide.classList.toggle('visible', i === this.currentSlide);
+                });
+                const build = this.buildOn(this.slides[this.currentSlide]);
+                if (build) build.reset();
+            }
+        }
+
+        const deck = new SlidePresentation();
+
+        const editor = {
+            isActive: false,
+            toggleEditMode() {
+                this.isActive = !this.isActive;
+                document.getElementById('editToggle').classList.toggle('active', this.isActive);
+                document.querySelectorAll('h1,h2,p,strong,small').forEach((el) => {
+                    el.setAttribute('contenteditable', this.isActive ? 'true' : 'false');
+                });
+            }
+        };
+
+        const editToggle = document.getElementById('editToggle');
+        const hotzone = document.querySelector('.edit-hotzone');
+        let hideTimeout = null;
+
+        editToggle.addEventListener('click', () => editor.toggleEditMode());
+        hotzone.addEventListener('mouseenter', () => {
+            clearTimeout(hideTimeout);
+            editToggle.classList.add('show');
+        });
+        hotzone.addEventListener('mouseleave', () => {
+            hideTimeout = setTimeout(() => {
+                if (!editor.isActive) editToggle.classList.remove('show');
+            }, 400);
+        });
+        editToggle.addEventListener('mouseenter', () => clearTimeout(hideTimeout));
+        editToggle.addEventListener('mouseleave', () => {
+            hideTimeout = setTimeout(() => {
+                if (!editor.isActive) editToggle.classList.remove('show');
+            }, 400);
+        });
+        hotzone.addEventListener('click', () => editor.toggleEditMode());
+        document.addEventListener('keydown', (e) => {
+            if ((e.key === 'e' || e.key === 'E') && !e.target.getAttribute('contenteditable')) {
+                editor.toggleEditMode();
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Why

Save the in-progress AgentKit talk so it can be resumed later and hosted on this site.

## What

- Live 16:9 deck at `/talks/agentkit` (Scalekit look, no site chrome)
- Arrow keys build the architecture and sequence diagrams one piece at a time
- Official tool names (`github_pull_request_get`, `github-connect`)
- Research notes in `docs/research/agentkit-talk.md`

## How to open

`public/talks/agentkit/index.html`, or after deploy: `saifshines.dev/talks/agentkit`

Not wired into Work/nav yet. Demo links and a Work entry are still open.